### PR TITLE
Fix ProForma writer for ranges bearing multiple modifications (§4.5)

### DIFF
--- a/src/TopDownProteomics/ProForma/ProFormaWriter.cs
+++ b/src/TopDownProteomics/ProForma/ProFormaWriter.cs
@@ -103,13 +103,18 @@ namespace TopDownProteomics.ProForma
 
                     bool hasAmbiguousSequence = obj is ProFormaTag tag2 && tag2.HasAmbiguousSequence;
 
+                    // Additional tags that share this exact range are extra modifications on the same
+                    // range (e.g. "(SEQ)[mod1][mod2]"); they are written after the range closes and are
+                    // not nested ranges.
+                    List<(object, int, int, bool, double)>? sameRangeTags = null;
+
                     if (startIndex == endIndex && !hasAmbiguousSequence)
                     {
                         // Write sequence up to tag
                         sb.Append(term.Sequence.Substring(currentIndex, startIndex - currentIndex + 1));
                         currentIndex = startIndex + 1;
                     }
-                    else // Handle ambiguity range
+                    else // Handle a range (ambiguity range, or a range bearing one or more modifications)
                     {
                         // Write sequence up to range (checking for internal tags)
                         sb.Append(term.Sequence[currentIndex..startIndex]);
@@ -121,19 +126,29 @@ namespace TopDownProteomics.ProForma
                         if (hasAmbiguousSequence)
                             sb.Append('?');
 
-                        // Check for other tags that might be inside this range
+                        // Check for other tags that fall within this range
                         int j = i + 1;
                         while (j < tagsAndGroups.Count && tagsAndGroups[j].Item2 <= endIndex)
                         {
                             (object, int, int, bool, double) internalTag = tagsAndGroups[j];
 
-                            if (internalTag.Item2 != internalTag.Item3)
+                            if (internalTag.Item2 == startIndex && internalTag.Item3 == endIndex)
+                            {
+                                // Another modification on the same range; emit it after the ')'.
+                                (sameRangeTags ??= new List<(object, int, int, bool, double)>()).Add(internalTag);
+                            }
+                            else if (internalTag.Item2 != internalTag.Item3)
+                            {
                                 throw new ProFormaParseException("Can't nest ranges within each other.");
+                            }
+                            else
+                            {
+                                // A single-residue tag located inside the range.
+                                sb.Append(term.Sequence[currentIndex..(internalTag.Item2 + 1)]);
+                                currentIndex = internalTag.Item2 + 1;
 
-                            sb.Append(term.Sequence[currentIndex..(internalTag.Item2 + 1)]);
-                            currentIndex = internalTag.Item2 + 1;
-
-                            WriteTagOrGroup(internalTag.Item1, sb, internalTag.Item4, internalTag.Item5);
+                                WriteTagOrGroup(internalTag.Item1, sb, internalTag.Item4, internalTag.Item5);
+                            }
 
                             j++;
                             i++;
@@ -144,6 +159,12 @@ namespace TopDownProteomics.ProForma
                     }
 
                     WriteTagOrGroup(obj, sb, displayValue, weight);
+
+                    if (sameRangeTags != null)
+                    {
+                        foreach (var extra in sameRangeTags)
+                            WriteTagOrGroup(extra.Item1, sb, extra.Item4, extra.Item5);
+                    }
                 }
 
                 // Write the rest of the sequence

--- a/tests/TopDownProteomics.Tests/ProForma/ProFormaWriterTests.cs
+++ b/tests/TopDownProteomics.Tests/ProForma/ProFormaWriterTests.cs
@@ -365,5 +365,34 @@ namespace TopDownProteomics.Tests.ProForma
 
             Assert.AreEqual("SE(?Q)UENCE", result);
         }
+
+        [Test]
+        public void WriteMultipleModificationsOnSameRange()
+        {
+            // A range bearing more than one modification: "(SEQ)[mod1][mod2]" (ProForma 2.0 section 4.5).
+            // Each modification is a separate tag spanning the same range; they must be emitted as
+            // consecutive descriptors after the range, not treated as nested ranges.
+            var term = new ProFormaTerm("SEQUENCE", tags: new[]
+            {
+                new ProFormaTag(2, 5, new[] { new ProFormaDescriptor(ProFormaKey.Mass, "+14.05") }),
+                new ProFormaTag(2, 5, new[] { new ProFormaDescriptor(ProFormaKey.Name, "Oxidation") })
+            });
+            var result = _writer.WriteString(term);
+
+            Assert.AreEqual("SE(QUEN)[+14.05][Oxidation]CE", result);
+        }
+
+        [Test]
+        public void RoundTripMultipleModificationsOnRange()
+        {
+            // Regression for the "Can't nest ranges within each other" writer bug on a range that
+            // carries several modifications (ProForma 2.0 section 4.5).
+            var parser = new ProFormaParser();
+            string proForma = "PRT(ESFRMS)[Oxidation][Oxidation][half cystine][half cystine]ISK";
+
+            string written = _writer.WriteString(parser.ParseString(proForma));
+
+            Assert.AreEqual(proForma, written);
+        }
     }
 }

--- a/tests/TopDownProteomics.Tests/ProForma/ProFormaWriterTests.cs
+++ b/tests/TopDownProteomics.Tests/ProForma/ProFormaWriterTests.cs
@@ -394,5 +394,35 @@ namespace TopDownProteomics.Tests.ProForma
 
             Assert.AreEqual(proForma, written);
         }
+
+        [Test]
+        public void WriteSingleResidueModificationInsideRange()
+        {
+            // A point modification localized to one residue that sits inside a range:
+            // the inner residue tag is written within the range parentheses, the range
+            // descriptor after the closing ')'.
+            var term = new ProFormaTerm("SEQUENCE", tags: new[]
+            {
+                new ProFormaTag(1, 5, new[] { new ProFormaDescriptor(ProFormaKey.Mass, "+14.05") }),
+                new ProFormaTag(3, new[] { new ProFormaDescriptor(ProFormaKey.Name, "Oxidation") })
+            });
+            var result = _writer.WriteString(term);
+
+            Assert.AreEqual("S(EQU[Oxidation]EN)[+14.05]CE", result);
+        }
+
+        [Test]
+        public void WriteNestedRangesThrows()
+        {
+            // A genuine range nested inside another range (distinct start/end pairs) is invalid
+            // ProForma and must still be rejected.
+            var term = new ProFormaTerm("SEQUENCE", tags: new[]
+            {
+                new ProFormaTag(1, 5, new[] { new ProFormaDescriptor(ProFormaKey.Mass, "+14.05") }),
+                new ProFormaTag(2, 4, new[] { new ProFormaDescriptor(ProFormaKey.Name, "Oxidation") })
+            });
+
+            Assert.Throws<ProFormaParseException>(() => _writer.WriteString(term));
+        }
     }
 }


### PR DESCRIPTION
## Problem

`ProFormaWriter.WriteString` throws `ProFormaParseException: "Can't nest ranges within each other."` whenever a term contains a sequence **range that carries more than one modification** — the ProForma 2.0 §4.5 construct `(SEQ)[mod1][mod2]…`. The parser accepts these strings, so they cannot currently be round-tripped: parsing succeeds but writing the resulting term fails.

### Reproduce
```csharp
var parser = new ProFormaParser();
var writer = new ProFormaWriter();
var term = parser.ParseString("PRT(ESFRMS)[Oxidation][Oxidation][half cystine][half cystine]ISK");
writer.WriteString(term);   // throws: Can't nest ranges within each other.
```
This also blocks real specification examples (e.g. the §4.5 insulin-style range bearing multiple oxidations and half-cystines).

## Root cause

Each modification on a range is parsed as a **separate `ProFormaTag` spanning the same `(ZeroBasedStartIndex, ZeroBasedEndIndex)`** — the parser keeps the range open across consecutive `)[mod][mod]` until the next residue resets it. When the writer reaches the range, its inner loop scans the tags that fall within the range and unconditionally throws for any whose `start != end`. But a *co-located range modification* legitimately has `start != end` (it spans the whole range), so these were mistaken for nested ranges.

## Fix

In the range branch of `WriteString`, a tag whose start **and** end equal the current range's start and end is treated as another modification on that same range and emitted as a consecutive `[descriptor]` after the range closes. Genuinely nested ranges (a different `start != end` inside the range) still throw as before.

### After
```
PRT(ESFRMS)[Oxidation][Oxidation][half cystine][half cystine]ISK   // round-trips unchanged
SE(QUEN)[+14.05][Oxidation]CE                                       // two modifications on one range
```

## Tests

- `WriteMultipleModificationsOnSameRange` — constructs a range carrying two modifications and asserts `SE(QUEN)[+14.05][Oxidation]CE`.
- `RoundTripMultipleModificationsOnRange` — parse→write round-trip of a four-modification range.
- Full suite green: **235 passed, 7 skipped, 0 failed** (net472 + net6.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JNnpzBNwfnTbZxtZdtAzLG
