### PR TITLE
Reject ontology accessions written under a short source prefix (U:/M:/R:)

### DIFF
--- a/src/TopDownProteomics/ProForma/ProFormaParser.cs
+++ b/src/TopDownProteomics/ProForma/ProFormaParser.cs
@@ -440,15 +440,76 @@ namespace TopDownProteomics.ProForma
                 "gno" => Tuple.Create(ProFormaKey.Identifier, ProFormaEvidenceType.Gno, text, groupName, weight),
 
                 // Handle names and masses
-                "u" => Tuple.Create(getKey(isMass), ProFormaEvidenceType.Unimod, text.Substring(colon + 1), groupName, weight),
-                "m" => Tuple.Create(getKey(isMass), ProFormaEvidenceType.PsiMod, text.Substring(colon + 1), groupName, weight),
-                "r" => Tuple.Create(getKey(isMass), ProFormaEvidenceType.Resid, text.Substring(colon + 1), groupName, weight),
-                "x" => Tuple.Create(getKey(isMass), ProFormaEvidenceType.XlMod, text.Substring(colon + 1), groupName, weight),
-                "g" => Tuple.Create(getKey(isMass), ProFormaEvidenceType.Gno, text.Substring(colon + 1), groupName, weight),
-                "b" => Tuple.Create(getKey(isMass), ProFormaEvidenceType.Brno, text.Substring(colon + 1), groupName, weight),
-                "obs" => Tuple.Create(getKey(isMass), ProFormaEvidenceType.Observed, text.Substring(colon + 1), groupName, weight),
+                "u" => this.CreateNameOrMass(isMass, ProFormaEvidenceType.Unimod, text.Substring(colon + 1), groupName, weight),
+                "m" => this.CreateNameOrMass(isMass, ProFormaEvidenceType.PsiMod, text.Substring(colon + 1), groupName, weight),
+                "r" => this.CreateNameOrMass(isMass, ProFormaEvidenceType.Resid, text.Substring(colon + 1), groupName, weight),
+                "x" => this.CreateNameOrMass(isMass, ProFormaEvidenceType.XlMod, text.Substring(colon + 1), groupName, weight),
+                "g" => this.CreateNameOrMass(isMass, ProFormaEvidenceType.Gno, text.Substring(colon + 1), groupName, weight),
+                "b" => this.CreateNameOrMass(isMass, ProFormaEvidenceType.Brno, text.Substring(colon + 1), groupName, weight),
+                "obs" => this.CreateNameOrMass(isMass, ProFormaEvidenceType.Observed, text.Substring(colon + 1), groupName, weight),
 
                 _ => Tuple.Create(ProFormaKey.Name, ProFormaEvidenceType.None, text, groupName, weight)
+            };
+        }
+
+        /// <summary>
+        /// Creates a name or mass descriptor for a short ontology source prefix (U:, M:, R:, ...).
+        /// A short prefix denotes a modification NAME; when the value is written in the accession
+        /// format of its ontology (e.g. "U:35" or "R:AA0581") the full accession prefix
+        /// (UNIMOD:, MOD:, RESID:) was intended. ProForma 2.0 lists such forms as invalid, so they
+        /// are rejected here rather than silently treated as a (non-existent) name.
+        /// </summary>
+        private Tuple<ProFormaKey, ProFormaEvidenceType, string, string?, double> CreateNameOrMass(
+            bool isMass, ProFormaEvidenceType evidenceType, string value, string? groupName, double weight)
+        {
+            ProFormaKey key = isMass ? ProFormaKey.Mass : ProFormaKey.Name;
+
+            if (key == ProFormaKey.Name)
+            {
+                string? accessionPrefix = GetMisusedAccessionPrefix(evidenceType, value);
+
+                if (accessionPrefix != null)
+                    throw new ProFormaParseException(
+                        $"'{value}' is in {accessionPrefix} accession format; use the full accession " +
+                        $"prefix (e.g. [{accessionPrefix}:{value}]) instead of the short source prefix.");
+            }
+
+            return Tuple.Create(key, evidenceType, value, groupName, weight);
+        }
+
+        /// <summary>
+        /// Returns the full accession prefix a value should have used when it is written in the
+        /// accession format of its ontology under a short source prefix, or <c>null</c> otherwise.
+        /// </summary>
+        private static string? GetMisusedAccessionPrefix(ProFormaEvidenceType evidenceType, string value)
+        {
+            static bool IsAllDigits(string s)
+            {
+                if (s.Length == 0)
+                    return false;
+                foreach (char c in s)
+                    if (!char.IsDigit(c))
+                        return false;
+                return true;
+            }
+
+            static bool IsResidAccession(string s)
+            {
+                // RESID accessions are "AA" followed by digits, e.g. AA0581.
+                if (s.Length < 3 || s[0] != 'A' || s[1] != 'A')
+                    return false;
+                for (int i = 2; i < s.Length; i++)
+                    if (!char.IsDigit(s[i]))
+                        return false;
+                return true;
+            }
+
+            return evidenceType switch
+            {
+                ProFormaEvidenceType.Unimod when IsAllDigits(value) => "UNIMOD",
+                ProFormaEvidenceType.PsiMod when IsAllDigits(value) => "MOD",
+                ProFormaEvidenceType.Resid when IsResidAccession(value) => "RESID",
+                _ => null
             };
         }
     }

--- a/tests/TopDownProteomics.Tests/ProForma/ProFormaParserTests.cs
+++ b/tests/TopDownProteomics.Tests/ProForma/ProFormaParserTests.cs
@@ -1144,5 +1144,25 @@ namespace TopDownProteomics.Tests
             Assert.AreEqual("UNIMOD:15", desc1.Value);
         }
         #endregion
+
+        [Test]
+        public void RejectAccessionUnderShortSourcePrefix()
+        {
+            // ProForma 2.0: an ontology accession must use the full prefix (UNIMOD:/MOD:/RESID:).
+            // Writing the accession under the short name prefix (U:/M:/R:) is invalid.
+            Assert.Throws<ProFormaParseException>(() => _parser.ParseString("EM[U:35]EVEES[U:56]PEK"));
+            Assert.Throws<ProFormaParseException>(() => _parser.ParseString("EM[M:00719]EVEES[M:00046]PEK"));
+            Assert.Throws<ProFormaParseException>(() => _parser.ParseString("EM[R:AA0581]EVEES[R:AA0037]PEK"));
+        }
+
+        [Test]
+        public void AllowNamesAndMassesUnderShortSourcePrefix()
+        {
+            // Real names and source-tagged masses under the short prefix remain valid.
+            Assert.DoesNotThrow(() => _parser.ParseString("EM[U:Oxidation]EVEES[U:Phospho]PEK"));
+            Assert.DoesNotThrow(() => _parser.ParseString("EM[M:L-methionine sulfoxide]EVEES[M:O-phospho-L-serine]PEK"));
+            Assert.DoesNotThrow(() => _parser.ParseString("EM[U:+15.9949]EVEES[U:+79.9663]PEK"));
+            Assert.DoesNotThrow(() => _parser.ParseString("EM[R: L-methionine sulfone]EVEESPEK"));
+        }
     }
 }


### PR DESCRIPTION
## Summary

`[U:35]`, `[M:00719]`, and `[R:AA0581]` are listed in the ProForma 2.0 specification as **invalid** counter-examples: an ontology accession must use the full prefix (`UNIMOD:`, `MOD:`, `RESID:`), whereas the short prefixes (`U:`, `M:`, `R:`) denote modification **names**. The parser currently accepts these as a name (e.g. a Unimod modification literally named `"35"`), so the three spec counter-examples round-trip instead of being rejected.

This PR rejects a name value that is written in the accession format of its ontology:

```csharp
new ProFormaParser().ParseString("EM[U:35]EVEES[U:56]PEK");       // now throws ProFormaParseException
new ProFormaParser().ParseString("EM[M:00719]EVEESPEK");          // now throws
new ProFormaParser().ParseString("EM[R:AA0581]EVEESPEK");         // now throws

new ProFormaParser().ParseString("EM[U:Oxidation]EVEES[U:Phospho]PEK");   // still valid (real name)
new ProFormaParser().ParseString("EM[U:+15.9949]EVEESPEK");              // still valid (source-tagged mass)
```

Detection is deliberately narrow — Unimod/PSI-MOD: all-digits; RESID: `AA` + digits — matching the three documented counter-examples, and only applies to `Name` descriptors (masses and real names are untouched). The same idea could extend to `X:` (XLMOD) / `G:` (GNO) if desired.

## 🟨 This is a policy/judgment call — your decision

This is **not a clear-cut bug** — it's a question of where validation belongs. The parser is otherwise syntactic, and `[U:35]` is *syntactically* well-formed (a name "35"); its invalidity is *semantic* (no such name exists), which a downstream resolver/validator would also catch. We're happy to:

- merge as-is (parser rejects accession-shaped values under short prefixes), or
- scope it differently (e.g. behind an option, or limited to specific ontologies), or
- close it if you'd rather keep this check in a validation layer rather than the parser.

Whatever you prefer. The implementation is small and self-contained either way.

## Tests
- `RejectAccessionUnderShortSourcePrefix` — the three spec counter-examples now throw.
- `AllowNamesAndMassesUnderShortSourcePrefix` — real names and source-tagged masses still parse.
- Full suite green: **235 passed, 7 skipped, 0 failed** (net472 + net6.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JNnpzBNwfnTbZxtZdtAzLG
